### PR TITLE
Update Limited_Information_Strategies_and_Discrete_Selectivity.tex

### DIFF
--- a/Limited_Information_Strategies_and_Discrete_Selectivity.tex
+++ b/Limited_Information_Strategies_and_Discrete_Selectivity.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt]{article}
+\documentclass{amsart}
 
 \usepackage{amssymb}
 \usepackage{amsfonts}
@@ -47,189 +47,502 @@
       \theoremstyle{remark}
       \newtheorem*{remark*}{Remark}
 
-\title{Limited Information Strategies and Discrete Selectivity}
-\author{Steven Clontz and Jared Holshouser}
-
 \usepackage{clontzDefinitions}
 
 \newcommand{\bmPoGame}[2]{BM_{po}(#1,#2)}
 
 \begin{document}
 
+\title{Limited Information Strategies and Discrete Selectivity}
+\author{Steven Clontz and Jared Holshouser}
+\address{Department of Mathematics and Statistics,
+The University of South Alabama,
+Mobile, AL 36688}
+\email{sclontz@southalabama.edu}
+\email{JaredHolshouser@southalabama.edu}
+
+\keywords{Selection property, selection game, point picking game,
+limited information strategies, covering properties, Cp theory}
+
+\subjclass[2010]{54C30, 54D20, 54D45, 91A44}
+
+\begin{abstract}
+ We relate the property of discrete selectivity and its corresponding game, both recently introduced by V.V> Tkachuck, to a variety of selection principles and point picking games. In particular we show that II can win the discrete selection game on \(C_p(X)\) if and only if II can win a variant of the point open game on \(X\). We also show that the existence of limited information starategies in the discrete selection game on \(C_p(X)\) for either player are equivalent to other well-known topological properties.
+\end{abstract}
+
 \maketitle
+
+\section{Introduction}
+
+In the course of studying the strong domination of function spaces by second countable spaces and countable spaces, G. Sanchez and Tkachuk isolated the topological property of discrete selectivity.
+A space is discretely selective if for every sequence \(\{U_n : n \in \omega\}\) of non-empty open subsets of the space, there are points \(x_n \in U_n\) so that \(\{x_n : n \in \omega\}\) is closed discrete.
+In subsequent work, V.V. Tkachuk showed that for \(T_{3.5}\)-spaces, \(C_p(X)\) is discretely selective if and only if \(X\) is uncountable.
+
+Discrete selectivity naturally generates a game, in which player I plays open sets, player II responds with points from those open sets, and player II wins if the points form a closed discrete set.
+Tkachuk explored what happens when player I  perfect information strategy in this game, showing that player I has a strategy in this game on \(C_p(X)\) is equivalent to player I having a strategy for Gruenhage's \(W\)-game on \(C_p(X,\mathbf 0)\) and is also equivalent to player I having a strategy for the point-open game on \(X\).
+Tkachuk also showed that if player II has a strategy in the point-open game on \(X\), then player II has a strategy in the discrete selection game on \(C_p(X)\).
+Tkachuk hypothesized that the implication reverses for player II, and posed this problem as an open question.
+
+By considering lower information strategies and other topological games, we were able to answer Tkachuk's question and uncover a number of interesting connections between the discrete selection game and other topological properties.
+Classic works by Telgarksy and Galvin show that the point open game is dual to the Rothberger game.
+Clontz, in work prior to this, established the equivalence of the existence of strategies for the Rothberger game and variants of the Rothberger game for \(X\)  to the existence of strategies in games related to countable fan tightness for \(C_p(X)\).
+Clontz did this both for strategies of perfect information and for limited information strategies.
+Starting with these results, we are able to relate a host of games on \(C_p(X)\) and \(X\) for strategies of limited information and perfect information.
+As a result we answer Tkachuk's question: player II has a strategy for the discrete selection game on \(C_p(X)\) if and only if player II has a strategy for the \(\omega\)-cover variant of the finite-open game.
+The \(\omega\)-cover variant of the finite-open game is closely related to the point open game, but it is consistent that they are different.
+Tkachuk referred to a strategy for this variant for player II as an almost winning strategy.
+So in Tkachuk's terminology, player II has a strategy for the discrete selection game on \(C_p(X)\) if and only if player II has an almost winning strategy for the point-open game.
+Moreover, we answer the implied question ``what topological property does a strategy for player II for the discrete selection game on \(C_p(X)\) correspond to?''
+We show that player II has a strategy for the discrete selection game on \(C_p(X)\) if and only if \(X\) is not Rothberger with respect to \(\omega\)-covers.
+This in turn is true if and only if some finite power of \(X\) is not Lindelof.
 
 \section{Definitions}
 
+We will be using a number of definitions.
+These are broken up into three main categories: labeling schema, topological notions, and games.
+
+\subsection{Labeling Schema}
+
 \begin{definition}
-  The \term{selection principle} \(\schSelProp{\mc A}{\mc B}\) states that
-  given \(A_n\in\mc A\) for \(n<\omega\), there exist \(B_n\in[A_n]^{<\omega}\)
-  such that \(\bigcup_{n<\omega}B_n\in\mc B\).
+ The \term{selection principle} \(\schSelProp{\mc A}{\mc B}\) states that given \(A_n\in\mc A\) for \(n<\omega\), there exist \(B_n\in[A_n]^{<\omega}\) such that \(\bigcup_{n<\omega}B_n\in\mc B\).
 \end{definition}
 
 \begin{definition}
-  The \term{selection game} \(\schSelGame{\mc A}{\mc B}\) is the
-  analogous game to \(\schSelProp{\mc A}{\mc B}\), where during each
-  round \(n<\omega\), Player \(\plI\) first
-  chooses \(A_n\in\mc A\), and then Player \(\plII\) chooses
-  \(B_n\in[A_n]^{<\omega}\).
-  Player \(\plII\) wins in the case that \(\bigcup_{n<\omega}B_n\in\mc B\),
-  and Player \(\plI\) wins otherwise.
+ The \term{selection game} \(\schSelGame{\mc A}{\mc B}\) is the analogous game to \(\schSelProp{\mc A}{\mc B}\), where during each round \(n<\omega\), Player \(\plI\) first chooses \(A_n\in\mc A\), and then Player \(\plII\) chooses \(B_n\in[A_n]^{<\omega}\).
+ Player \(\plII\) wins in the case that \(\bigcup_{n<\omega}B_n\in\mc B\), and Player \(\plI\) wins otherwise.
 \end{definition}
 
 \begin{definition}
-  Let \(\mc O_X\) be the collection of open covers for a topological space
-  \(X\). Then \(\schSelProp{\mc O_X}{\mc O_X}\) is the well-known
-  \term{Menger property} for \(X\) (\(M\) for short), and
-  \(\schSelGame{\mc O_X}{\mc O_X}\) is the
-  well-known \term{Menger game}.
+  A \term{strategy} for \(\plII\) in the game \(\schSelGame{\mc A}{\mc B}\) is a function \(\sigma\) satisfying \(\sigma(\<A_0,\dots,A_n\>)\in[A_n]^{<\omega}\) for \(\<A_0\,\dots,A_n\>\in\mc A^{n+1}\).
+  We say this strategy is \term{winning} if whenever \(\plI\) plays \(A_n\in\mc A\) during each round \(n<\omega\), \(\plII\) wins the game by playing \(\sigma(\<A_0,\dots,A_n\>)\) during each round \(n<\omega\).
+  If a winning strategy exists, then we write \(\plII\win\schSelGame{\mc A}{\mc B}\).
 \end{definition}
 
 \begin{definition}
-  An \term{\(\omega\)-cover} \(\mc U\)
-  for a topological space \(X\) is an open cover
-  such that for every \(F\in[X]^{<\omega}\), there exists some \(U\in\mc U\)
-  such that \(F\subseteq U\).
+  A \term{Markov strategy} for \(\plII\) in the game \(\schSelGame{\mc A}{\mc B}\) is a function \(\sigma\) satisfying \(\sigma(A,n)\in[A_n]^{<\omega}\) for \(A\in\mc A\) and \(n<\omega\). We say this Markov strategy is \term{winning} if whenever \(\plI\) plays \(A_n\in\mc A\) during each round \(n<\omega\), \(\plII\) wins the game by playing \(\sigma(A_n,n)\) during each round \(n<\omega\). 
+  If a winning Markov strategy exists, then we write \(\plII\markwin\schSelGame{\mc A}{\mc B}\).
 \end{definition}
 
 \begin{definition}
-  Let \(\Omega_X\) be the collection of \(\omega\)-covers for a topological
-  space \(X\). Then \(\schSelProp{\Omega_X}{\Omega_X}\) is the
-  \term{\(\Omega\)-Menger property} for \(X\) (\(\Omega M\) for short), and
-  \(\schSelGame{\Omega_X}{\Omega_X}\) is the \term{\(\Omega\)-Menger game}.
-\end{definition}
-
-\begin{definition}
-  Let \(\Omega_{X,x}\) be the collection of subsets \(A\subset X\) where
-  \(x\in\closure{A}\). (Call \(A\) a \term{blade} of \(x\).)
-  Then \(\schSelProp{\Omega_{X,x}}{\Omega_{X,x}}\) is the
-  \term{countable fan tightness property} for \(X\) at \(x\)
-  (\(CFT_x\) for short), and
-  \(\schSelGame{\Omega_{X,x}}{\Omega_{X,x}}\) is the
-  \term{countable fan tightness game} for \(X\) at \(x\).
-\end{definition}
-
-\begin{definition}
-  A space \(X\) has \term{countable fan tightness} (\(CFT\) for short)
-  if it has
-  countable fan tightness at each point \(x\in X\).
-\end{definition}
-
-\begin{definition}
-  Let \(\mc D_{X}\) be the collection of dense subsets of a topological
-  space \(X\).
-  Then \(\schSelProp{\mc D_X}{\Omega_{X,x}}\) is the
-  \term{countable dense fan tightness property} for \(X\) at \(x\)
-  (\(CDFT_x\) for short), and
-  \(\schSelGame{\mc D_X}{\Omega_{X,x}}\) is the
-  \term{countable dense fan tightness game} for \(X\) at \(x\).
-\end{definition}
-
-\begin{definition}
-  A space \(X\) has \term{countable dense fan tightness}
-  (\(CDFT\) for short) if it has
-  countable dense fan tightness at each point \(x\in X\).
-\end{definition}
-
-\begin{definition}
-  \(\schSelProp{\mc D_X}{\mc D_X}\) is the
-  \term{selective separability property} for \(X\)
-  (\(SS\) for short), and
-  \(\schSelGame{\mc D_X}{\mc D_X}\) is the
-  \term{selective separability game} for \(X\).
-\end{definition}
-
-\begin{definition}
-  A \term{strategy} for \(\plII\) in the game \(\schSelGame{\mc A}{\mc B}\)
-  is a function \(\sigma\) satisfying
-  \(\sigma(\<A_0,\dots,A_n\>)\in[A_n]^{<\omega}\) for
-  \(\<A_0\,\dots,A_n\>\in\mc A^{n+1}\). We say this strategy is
-  \term{winning} if whenever \(\plI\) plays \(A_n\in\mc A\) during each
-  round \(n<\omega\), \(\plII\) wins the game by playing
-  \(\sigma(\<A_0,\dots,A_n\>)\) during each round \(n<\omega\).
-  If a winning strategy exists, then we write
-  \(\plII\win\schSelGame{\mc A}{\mc B}\).
-\end{definition}
-
-\begin{definition}
-  A \term{Markov strategy} for \(\plII\) in the game
-  \(\schSelGame{\mc A}{\mc B}\)
-  is a function \(\sigma\) satisfying
-  \(\sigma(A,n)\in[A_n]^{<\omega}\) for
-  \(A\in\mc A\) and \(n<\omega\). We say this Markov strategy is
-  \term{winning} if whenever \(\plI\) plays \(A_n\in\mc A\) during each
-  round \(n<\omega\), \(\plII\) wins the game by playing
-  \(\sigma(A_n,n)\) during each round \(n<\omega\).
-  If a winning Markov strategy exists, then we write
-  \(\plII\markwin\schSelGame{\mc A}{\mc B}\).
-\end{definition}
-
-\begin{definition}
-In some instances, player I will be able to win a game regardless of what II is playing.
-In this case, it is possible to have a strategy for I which depends only on the round of the game.
-We say I has a \term{pre-determined strategy} and write \(\plI\prewin G\).
+ In some instances, player I will be able to win a game regardless of what II is playing.
+ In this case, it is possible to have a strategy for I which depends only on the round of the game.
+ We say I has a \term{pre-determined strategy} and write \(\plI\prewin G\).
 \end{definition}
 
 \begin{notation}
-  If \(\schSelProp{\mc A}{\mc B}\) characterizes the property \(P\),
-  then we say \(\plII\win\schSelGame{\mc A}{\mc B}\) characterizes
-  \(P^+\) (``strategically \(P\)''), and
-  \(\plII\markwin\schSelGame{\mc A}{\mc B}\) characterizes
-  \(P^{\plusMark}\) (``Markov \(P\)'').
-  Of course, \(P^{\plusMark}\Rightarrow P^+ \Rightarrow P\).
+ If \(\schSelProp{\mc A}{\mc B}\) characterizes the property \(P\), then we say \(\plII\win\schSelGame{\mc A}{\mc B}\) characterizes \(P^+\) (``strategically \(P\)''), and \(\plII\markwin\schSelGame{\mc A}{\mc B}\) characterizes \(P^{\plusMark}\) (``Markov \(P\)'').
+ Of course, \(P^{\plusMark}\Rightarrow P^+ \Rightarrow P\).
 \end{notation}
 
-\begin{notation}
-Let \(\schStrongSelProp{\mc A}{\mc B},\schStrongSelGame{\mc A}{\mc B}\)
-be the natural variants of
-\(\schSelProp{\mc A}{\mc B},\schSelGame{\mc A}{\mc B}\) where each choice
-by \(\plII\) must either be a single element or singleton
-(whichever is more convenient for the proof at hand), rather than a finite
-set. Convention calls for denoting these as
-\term{strong} versions of the corresponding selection principles and games,
-although the ``strong Menger'' property is commonly known as ``Rothberger''. We will thus
-call ``strong \(\Omega\)-Menger'' ``\(\Omega\)-Rothberger'' and shorten it
-with \(\Omega R\), and otherwise attach the prefix ``s''
-when abbreviating to all other strong variants.
-\end{notation}
-
-In addition to pure selection games, we also will be playing various point-picking games.
-
 \begin{definition}
-Set \(T(X)\) to be the non-empty open subsets of \(X\).
-The \term{point-open game} for \(X\), denoted \(PO(X)\), is played as follows.
-Each round, player I plays a point \(x_n \in X\) and player II plays an open sets \(U_n\) with the property that \(x_n \in U_n\).
-I wins the play of the game if \(X = \bigcup_n U_n\).
-
-The \term{finite-open game} for \(X\), denoted \(FO(x)\), is played similarly, except that I now plays finite subsets of \(X\), and II's open sets must cover I's finite set.
-Note that \(PO(X)\) is just \(sFO(S)\).
-\(\Omega FO(X)\) and \(\Omega PO(X)\) are defined according to convention: I now wins if \(\{U_n : n \in \omega\}\) forms an \(\omega\)-cover of \(X\).
+ Let \(\schStrongSelProp{\mc A}{\mc B},\schStrongSelGame{\mc A}{\mc B}\) be the natural variants of \(\schSelProp{\mc A}{\mc B},\schSelGame{\mc A}{\mc B}\) where each choice by \(\plII\) must either be a single element or singleton (whichever is more convenient for the proof at hand), rather than a finite set.
+ Convention calls for denoting these as \term{strong} versions of the corresponding selection principles and games, denoted here as \(sP\) for property \(P\), with a few exceptions for properties which already have their own names.
 \end{definition}
 
 \begin{definition}
-Let \(x \in X\).
-\term{Gruenhage's \(W\)-game} for \(x\), denoted \(\gruConGame{X}{x}\), is played as follows.
-Each round, player I plays an open set \(U_n\) with the property that \(x \in U_n\) and player II plays a point \(x_n \in U_n\).
-I wins if \(x_n \to x\).
-
-The \term{closure game} for \(x\), denoted \(CL(X,x)\), is played the same as Gruenhage's \(W\)-game, but now I wins if \(x \in \overline{\{x_n : n \in \omega\}}\).
-Note that this is \(\schStrongSelGame{T(X)}{\Omega_{X,x}}\).
-
-The \term{discrete selectivity game}, denoted \(CD(X)\), is also played the same as Gruenhage's \(W\)-game, but now II wins if \(\{x_n : n \in \omega\}\) is closed and discrete.
-Note that this is \(\schStrongSelGame{T(X)}{\mathcal{CD}}\) if we let \(\mathcal{CD}\) denoted the closed discrete subsets of \(X\).
+ We will use the following shorthand for various special colletions of subsets of \(X\).
+  \begin{itemize}
+   \item Let \(\mc O_X\) be the collection of open covers for a topological space   \(X\).
+   \item An \term{\(\omega\)-cover} \(\mc U\)   for a topological space \(X\) is an open cover   such that for every \(F\in[X]^{<\omega}\), there exists some \(U\in\mc U\)   such that \(F\subseteq U\). Let \(\Omega_X\) be the collection of \(\omega\)-covers for a topological   space \(X\).
+   \item Let \(\Omega_{X,x}\) be the collection of subsets \(A\subset X\) where   \(x\in\closure{A}\). (Call \(A\) a \term{blade} of \(x\).)
+   \item Let \(\mc D_{X}\) be the collection of dense subsets of a topological   space \(X\).
+   \item Set \(T(X)\) to be the non-empty open subsets of \(X\).
+  \end{itemize}
 \end{definition}
+
+\subsection{Topological Notions}
 
 \begin{definition}
-A space \(X\) is \term{discretely selective} iff 
+ Using the notation just established, we can record a number of topological properties.
+  \begin{itemize}
+   \item \(\schSelProp{\mc O_X}{\mc O_X}\) is the well-known \term{Menger property} for \(X\) (\(M\) for short).
+   \item \(\schStrongSelProp{\mc O_x}{\mc O_X}\) is then just the \term{Rothberger property} for \(X\) (\(R\) for short). We say this instead of \(sM\).
+   \item \(\schSelProp{\Omega_X}{\Omega_X}\) is the \term{\(\Omega\)-Menger property} for \(X\) (\(\Omega M\) for short).
+   \item \(\schStrongSelProp{\Omega_X}{\Omega_X}\) is the \term{\(\Omega\)-Rothberger property} for \(X\) (\(\Omega R\) for short). We say this instead of \(s\Omega M\).
+   \item \(\schSelProp{\Omega_{X,x}}{\Omega_{X,x}}\) is the \term{countable fan tightness property} for \(X\) at \(x\) (\(CFT_x\) for short). A space \(X\) has \term{countable fan tightness} (\(CFT\) for short)
+    if it has countable fan tightness at each point \(x\in X\).
+   \item  Then \(\schSelProp{\mc D_X}{\Omega_{X,x}}\) is the \term{countable dense fan tightness property} for \(X\) at \(x\) (\(CDFT_x\) for short). A space \(X\) has \term{countable dense fan tightness} (\(CDFT\) for short) if it has countable dense fan tightness at each point \(x\in X\).
+  \end{itemize}
 \end{definition}
 
-\section{2-marks in CD(X)}
+Tkachuk isolated the following the notion.
 
-Let 
-\(
-  [f,F,\epsilon]
-    =
-  \{g\in C_p(X):|g(x)-f(x)|<\epsilon\text{ for all }x\in F\}
-\).
+\begin{definition}
+ A space \(X\) is \term{discretely selective} if whenever \(\{U_n : n \in \omega\}\) is a sequence of open subsets of \(X\), there are points \(x_n \in U_n\) so that \(\{x_n : n \in \omega\}\) is closed discrete.
+\end{definition}
+
+We will use the following notation when working with \(C_p(X)\).
+
+\begin{definition}
+ Suppose \(X\) is \(T_{3.5}\).
+ Basic open subsets of \(C_p(X)\) will be written as
+ \[
+  [f,F,\epsilon] = \{g\in C_p(X):|g(x)-f(x)|<\epsilon\text{ for all }x\in F\}
+ \]
+ where \(f \in C_p(X)\), \(F\) is a finite subset of \(X\) and \(\epsilon > 0\) is a real number.
+ \(F\) is called the \term{support} of \([f,F,\epsilon]\).
+ We can extend the notion of support to all open \(U \subseteq C_p(X)\), label it \(\supp(U)\).
+\end{definition}
+
+\subsection{Topological Games}
+
+\begin{definition}
+ The following selection games will be played in this paper.
+ \begin{itemize}
+   \item \(\schSelGame{\mc O_X}{\mc O_X}\) is the well-known \term{Menger game}.
+   \item \(\schStrongSelGame{\mc O_X}{\mc O_X}\) is the \term{Rothberger game}.
+   \item \(\schSelGame{\Omega_X}{\Omega_X}\) is the \term{\(\Omega\)-Menger game}.
+   \item \(\schStrongSelGame{\Omega_X}{\Omega_X}\) is the \term{\(\Omega\)-Rothberger game}.
+   \item \(\schSelGame{\Omega_{X,x}}{\Omega_{X,x}}\) is the \term{countable fan tightness game} for \(X\) at \(x\).
+   \item \(\schSelGame{\mc D_X}{\Omega_{X,x}}\) is the \term{countable dense fan tightness game} for \(X\) at \(x\).
+ \end{itemize}
+\end{definition}
+  
+\begin{definition}
+ The following point-picking games will also be played in this paper.
+  \begin{itemize}
+   \item The \term{point-open game} for \(X\), denoted \(PO(X)\), is played as follows. Each round, player I plays a point \(x_n \in X\) and player II plays an open sets \(U_n\) with the property that \(x_n \in U_n\). I wins the play of the game if \(X = \bigcup_n U_n\).
+   \item The \term{finite-open game} for \(X\), denoted \(FO(x)\), is played similarly, except that I now plays finite subsets of \(X\), and II's open sets must cover I's finite set.
+   \item \(\Omega FO(X)\) and \(\Omega PO(X)\) are defined according to convention: I now wins if \(\{U_n : n \in \omega\}\) forms an \(\omega\)-cover of \(X\).
+   \item Fix \(x \in X\). \term{Gruenhage's \(W\)-game} for \(x\), denoted \(\gruConGame{X}{x}\), is played as follows. Each round, player I plays an open set \(U_n\) with the property that \(x \in U_n\) and player II plays a point \(x_n \in U_n\). I wins if \(x_n \to x\).
+   \item Fix \(x \in X\). \term{Gruenhage's clustering-game} for \(x\), denoted \(\gruClusGame{X}{x}\), is played the same as \(\gruConGame{X}{x}\), except that I wins if \(x\) is a cluster point of \(\{x_n : n \in \omega\}\).
+   \item Fix \(x \in X\). The \term{closure game} for \(x\), denoted \(CL(X,x)\), is played the same as \(\gruConGame{X}{x}\), except that I wins if \(x \in \overline{\{x_n : n \in \omega\}}\).
+   \item The \term{discrete selectivity game}, denoted \(CD(X)\), is also played the same as \(\gruConGame{X}{x}\), but now II wins if \(\{x_n : n \in \omega\}\) is closed and discrete.
+ \end{itemize}
+\end{definition}
+
+\section{Strategies for Player I for the Discrete Selection Game on \(C_p(X)\)}
+
+We begin by extending theorem 3.8 of Tkachuk to equate the existence of strategies for 11 games.
+
+\begin{theorem}
+ The following are equivalent for \(T_{3.5}\) spaces \(X\).
+ \begin{enumerate}[a)]
+  \item \(X\) is \(R^+\).
+  \item \(X\) is \(\Omega R^+\).
+  \item \(\plI\win PO(X)\). 
+  \item \(\plI\win FO(X)\).
+  \item \(\plI\win\Omega FO(x)\).
+  \item \(\plI\win \gruConGame{C_p(X)}{\mathbf 0}\).
+  \item \(\plI\win \gruClusGame{C_p(X)}{\mathbf 0}\).
+  \item \(\plI\win CL(C_p(X),\mathbf 0)\).
+  \item \(\plI\win CD(C_p(X))\).
+  \item \(C_p(X)\) is \(sCFT^+\).
+  \item \(C_p(X)\) is \(sCDFT^+\).
+ \end{enumerate}
+\end{theorem}
+
+\begin{proof}
+ (a) \(\Leftrightarrow\) (b) is true by [citation needed].
+
+ (a) \(\Leftrightarrow\) (c) is a well-known result of Galvin.
+
+ (c) \(\Leftrightarrow\) (d) is 4.3 of [Telgarksy 1975].
+  
+ (e) \(\Rightarrow\) (d) is clear, but we need to show that (b) \(\Rightarrow\) (e).
+ So assume \(X\) is \(\Omega R^+\). 
+ Let \(\sigma\) be a winning strategy for \(\plII\) in \(\schStrongSelGame{\Omega_X}{\Omega_X}\). 
+ Let \(T(X)\) be the non-empty open sets of \(X\), and let \(s\in T(X)^{<\omega}\). 
+ Assume \(\tau(t)\in[X]^{<\omega}\) is defined for all \(t<s\), and \(\mc U_t\in\Omega_X\) is defined for all \(\emptyset<t\leq s\). 
+
+ Suppose that for all \(F\in[X]^{<\omega}\), there existed \(U_F\in T(X)\) containing \(F\) such that for all \(\mc U\in\Omega_X\), \(U_F\not=\sigma(\<\mc U_{s\rest 1},\dots,U_s,\mc U\>)\). 
+ Let \(\mc U=\{U_F:F\in[X]^{<\omega}\}\in\Omega_X\). 
+ Then \(\sigma(\<\mc U_{s\rest 1},\dots,U_s,\mc U\>)\) must equal some \(U_F\), demonstrating a contradiction.
+
+ So there exists \(\tau(s)\in[X]^{<\omega}\) such that for all \(U\in T(X)\) containing \(\tau(s)\), there exists \(\mc U_{s\concat\<U\>}\in\Omega_X\) such that \(U=\sigma(\<\mc U_{s\rest 1},\dots,\mc U_s,\mc U_{s\concat\<U\>}\>)\). 
+ (To complete the induction, \(\mc U_{s\concat\<U\>}\) may be chosen arbitrarily for all other \(U\in T(X)\).)
+
+ So \(\tau\) is a strategy for \(\plI\) in \(\Omega FO(X)\). 
+ Let \(\nu\) legally attack \(\tau\), so \(\tau(\nu\rest n)\subseteq \nu(n)\) for all \(n<\omega\). 
+ It follows that \(\nu(n)=\sigma(\<\mc U_{\nu\rest 1},\dots,\mc U_{\nu\rest n},\mc U_{\nu\rest n+1}\>)\). 
+ Since \(\<\mc U_{\nu\rest 1},\mc U_{n\rest 2},\dots\>\) is a legal attack against \(\sigma\), it follows that \(\{\sigma(\<\mc U_{\nu\rest 1},\dots,\mc U_{\nu\rest n+1}\>):n<\omega\}=\{\nu(n):n<\omega\}\) is an \(\omega\)-cover. 
+ Therefore \(\tau\) is a winning strategy, verifying \(\plI\win\Omega FO(X)\).
+
+ The equivalence of (c), (f), (h), and (i) are given as 3.8 of [Tkachuk 2017].
+
+ The equivalence of (f) and (g) are given in [https://doi.org/10.1016/0016-660X(76)90024-6].
+  
+ The equivalence of (b), (j), and (k) are due to Clontz's Menger preprint.
+
+ (k) \(\Leftrightarrow\) (h) follows from 3.18a of [Tkachuk 2017].
+ Tkachuk referes to the \(sCDFT\) game at a point \(p\) and \(CLD(X,p)\).
+\end{proof}
+
+If we require the strategies for I for \(CD(C_p(X))\) to be low information, then it must be that \(X\) is countable, and so \(C_p(X)\) is first countable.
+Combining with several other results in the literature, we observe this behavior for a variety of games.
+
+\begin{theorem}
+The following are equivalent for \(T_{3.5}\) spaces \(X\).
+ \begin{enumerate}[a)]
+  \item \(X\) is countable.
+  \item \(X\) is \(R^{+mark}\).
+  \item \(X\) is \(\Omega R^{+mark}\).
+  \item \(\plI\prewin PO(X)\). 
+  \item \(\plI\prewin FO(X)\).
+  \item \(\plI\prewin\Omega FO(x)\).
+  \item \(C_p(X)\) is first-countable.
+  \item \(\plI\prewin \gruConGame{C_p(X)}{\mathbf 0}\).
+  \item \(\plI\prewin \gruClusGame{C_p(X)}{\mathbf 0}\).
+  \item \(\plI\prewin CL(C_p(X),\mathbf 0)\).
+  \item \(\plI\prewin CD(C_p(X))\).
+  \item \(C_p(X)\) is \(sCFT^{+mark}\).
+  \item \(C_p(X)\) is \(sCDFT^{+mark}\).
+ \end{enumerate}
+\end{theorem}
+
+\begin{proof}
+ (a) \(\Rightarrow\) (d) is straight-forward. 
+ So let \(\sigma\) be a predetermined strategy for \(\plI\) in \(PO(X)\). 
+ If \(x\not\in\{\sigma(n):n<\omega\}\), let \(f(n)=X\setminus\{x\}\) for all \(n<\omega\). It follows that \(f\) is a legal counter-attack for \(\plII\) defeating \(\sigma\). 
+ Thus not (a) implies not (d).
+
+ The equivalence of (b) and (d) was shown by Clontz in unpublished work.
+ We provide a proof here.
+ Let \(\sigma\) be a winning Markov strategy for \(\plII\) in \(\rothGame{X}\).
+ Let \(n<\omega\). Suppose that for each \(x\in X\), there was an open neighborhood \(U_x\) of \(x\) where for every open cover \(\mc U\), \(\sigma(\mc U,n)\not=U_x\). 
+ Then \(\sigma(\{U_x : x\in X\},n)\not\in\{U_x:x\in X\}\), a contradiction.
+
+ So for each \(n<\omega\), there exists \(\tau(n)\in X\) such that for any open neighborhood \(U\) of \(\tau(n)\), there exists an open cover \(\mc U_n\) such that \(\sigma(\mc U_n,n)=U\). 
+ Then \(\tau\) is a predetermined strategy for \(\plI\) in \(PO(X)\).
+
+ It is also winning: for every attack \(f\) against \(\tau\), note that \(f(n)\) is an open neighborhood of \(\tau(n)\), so choose \(\mc U_n\) such that \(\sigma(\mc U_n,n)=f(n)\). 
+ Then since \(\<\mc U_0,\mc U_1,\dots\>\) is a legal attack against \(\sigma\), it follows that \(\{f(n):n<\omega\}\) is an open cover of \(X\). 
+ Therefore \(\tau\) is a winning predetermined strategy.
+
+ Now let \(\sigma\) be a winning predetermined strategy for \(\plI\) in \(PO(X)\). 
+ For an open cover \(\mc U\) of \(X\) and \(n<\omega\), let \(\tau(\mc U,n)\) be any open set in \(\mc U\) containing \(\sigma(n)\). 
+ It follows that \(\tau\) is a winning Markov strategy for \(\plII\) in \(\rothGame{X}\).
+
+ Clearly (d) implies (e), so we will see that (e) implies (a). 
+ Let \(\sigma(n)\) be a pre-determined strategy for I for \(FO(X)\). 
+ Towards a contradiction, suppose that there is some \(x \in X \smallsetminus \bigcup_n \sigma(n)\).
+ II could then play \(FO(X)\) as follows.
+ At round \(n\) II can play an open set \(U_n\) which contains \(\sigma(n)\) but excludes \(x\).
+ Then \(x \notin \bigcup_n U_n\), and so I has lost.
+ This is a contradiction.
+ So \(X = \bigcup_n \sigma(n)\), which means it is countable.
+
+ It also clear that (f) implies (e), we will show that (a) implies (f).
+ If \(X\) is countable, then so is \([X]^{<\omega}\), enumerate it as \(\{s_n : n \in \omega\}\).
+ I's pre-determined strategy for \(\Omega FO(X)\) is to play \(s_n\) are round \(n\).
+ Clearly whatever II plays will be an \(\omega\)-cover.
+ Thus (a), (c), (d), (e), and (f) are equivalent.
+
+ It is well-known and easy to see that (a) is equivalent to (g).
+
+ To see that (g) implies (h), note that we can find a sequence of open sets \(U_n\) so that \(\mathbf 0 \in U_{n+1} \subseteq \overline{U_{n+1}} \subseteq U_n\) for all \(n\).
+ I simply plays \(U_n\) are turn \(n\), and whatever \(x_n\) are played by II must converge to \(x\).
+
+ Clearly (h) implies (j) which in turn implies (k), which is equivalent to (a) by [CLOSEDDISCRETESELECTIONS]
+
+ Clontz showed (h) and (i) are equivalent in his dissertation; it's not hard to prove this.
+
+ Clontz showed that (c), (l), and (m) are equivalent in his Menger/CFT preprint.
+
+ Note that (c) implies (b) implies (a).
+ So the last thing we need to show is that (f) implies (c).
+ Let \(\sigma(n)\) be a pre-determined strategy for I for \(\Omega FO(X)\).
+ We define a Markov strategy, \(\tau(\mathcal{U},n)\) for II for \(\Omega R\) as follows.
+ At round \(n\) suppose I has played \(\mathcal{U}\).
+ As \(\mathcal{U}\) must be an \(\omega\)-cover, there is a \(U \in \mathcal{U}\) so that \(\sigma(n) \subseteq U\).
+ II plays such a \(U_n\).
+ Now suppose this game has been played according to \(\tau\), and that I has played \(\mathcal{U}_n\) for \(n < \omega\).
+ Then the sequence of open sets \(\tau(\mathcal{U}_n,n)\) forms a legal play against \(\sigma\) for \(\Omega FO(X)\).
+ Thus \(\{\tau(\mathcal{U}_n,n) : n \in \omega\}\) is an \(\omega\)-cover of \(X\) and so \(\tau\) is a winning Markov strategy.
+\end{proof}
+
+In [CLOSEDDISCRETESELECTIONS], Tkachuk characterizes \(\plII\win\Omega FO(X)\) as the second player having an ``almost winning strategy'' (\(\plII\) can prevent \(\plI\) from constructing an \(\omega\)-cover but perhaps not an arbitrary open cover) in \(PO(X)\), which he conflates with \(FO(X)\) as they are equivalent for ``completely'' winning perfect information strategies. 
+
+But they cannot be interchanged in general. 
+Note that \(\plII\tactwin\Omega PO(2)\), where \(2\) is the two-point discrete space: let \(\sigma(\<x\>)=\{x\}\). Since every \(\omega\)-cover of \(2\) includes \(2\), and \(\sigma\) never produces \(2\), this is a winning tactic. 
+But since \(2\) is countable, \(2\) is \(\Omega R^{+mark}\). 
+So \(\Omega PO(X)\) is a very different game than those described previously.
+
+In [CLOSEDDISCRETESELECTIONS], Tkachuk showed that for \(T_{3.5}\) spaces \(X\), \(X\) is uncountable if and only if \(C_p(X)\) is discretely selective.
+Phrased in terms of games, Tkachuk showed the following.
+\begin{theorem}
+  For \(T_{3.5}\) spaces \(X\), \(X\) is uncountable if and only \(\plI\notprewin CD(C_p(X))\).
+\end{theorem}
+
+\section{Strategies for player II for the Discrete Selection Game on \(C_p(X)\)}
+
+\renewcommand{\rothGame}[1]{\ensuremath{G_1(\mc O_{#1},\mc O_{#1})}}
+
+Now we turn our attention to the opponent.
+We will begin by analyzing these games not just for \(T_{3.5}\) spaces \(X\) or on \(C_p(X)\), but in general.
+First off we will look at games related to open covers.
+
+\begin{proposition}
+ The following are equivalent for all spaces \(X\).
+ \begin{enumerate}[a)]
+  \item \(\plII\win PO(X)\).
+  \item \(\plII\markwin PO(X)\).
+  \item \(\plII\win FO(X)\).
+  \item \(\plII\markwin FO(X)\).
+  \item \(\plI\win \rothGame{X}\).
+  \item \(X\) is not \(R\), that is, \(\plI\prewin \rothGame{X}\).
+ \end{enumerate}
+\end{proposition}
+\begin{proof}
+ (a) \(\Leftrightarrow\) (c) is 4.4 of [Telgarksy 1975].
+
+ The duality of \(PO(X)\) and \(\rothGame{X}\) for both players when considering perfect information is a well-known result of Galvin. 
+ So (a) is equivalent to (e).
+
+ The equivalence of (e) and (f) is just a restatement of Pawlikowski's result that the Rothberger selection principle is equivalent to \(\plI\notwin \rothGame{X}\), since the Rothberger selection principle is equivalent to \(\plI\notprewin\rothGame{X}\).
+
+ (f) and (b) were shown to be equivalent by Clontz in unpublished work.
+ We provide a proof here.
+ Let \(\sigma\) be a winning predetermined strategy for \(\plI\) in \(\rothGame{X}\).
+ For \(x\in X\) and \(n<\omega\), let \(\tau(x,n)\) be any open set in \(\sigma(n)\) containing \(x\). 
+ It follows that \(\tau\) is a winning Markov strategy for \(\plII\) in \(PO(X)\).
+
+ Now let \(\sigma\) be a winning Markov strategy for \(\plII\) in \(PO(X)\).
+ We may defined the open cover \(\tau(n)=\{\sigma(x,n):x\in X\}\) of \(X\).
+ It follows that \(\tau\) is a winning predetermined strategy for \(\plI\) in \(\rothGame{X}\).
+
+ Finally, (d) implies (b) is obvious.
+ We therefore finish the proof by showing that (b) implies (d).
+ Let \(b:\omega^2\to\omega\) be a bijection.
+ Given a winning Markov strategy \(\sigma\) for \(\plII\) in \(PO(X)\), define \(\tau(F_n,n)=\bigcup\{\sigma(x(i,n),b(i,n)):i<\omega\}\) where \(F_n=\{x(i,n):i<\omega\}\) (this indexing will cause at least one point to be repeated infinitely often, but this won't be a problem). 
+ So given an attack \(\<F_0,F_1,\dots\>\) against \(\tau\), consider the attack \(g\) against \(\sigma\), where \(g(n)=x_{b^{\leftarrow}(n)}\). 
+ It follows that
+ \[
+   X \not= \bigcup\{\sigma(g(n),n):n<\omega\} = \bigcup\{\sigma(x(i,n),b(i,n)):i,n<\omega\} = \bigcup\{\tau(F_n,n):n<\omega\}
+ \]
+ and therefore \(\tau\) is a winning Markov strategy for \(\plII\).
+ Thus (b) implies (d).
+\end{proof}
+
+Next we will consider games related to \(\omega\)-covers.
+
+\begin{proposition}
+The following are equivalent for all spaces \(X\).
+ \begin{enumerate}[a)]
+  \item \(\plII\win \Omega FO(X)\).
+  \item \(\plII\markwin \Omega FO(X)\).
+  \item \(\plI\win G_1(\Omega_X,\Omega_X)\).
+  \item \(X\) is not \(\Omega R\), that is, \(\plI\prewin G_1(\Omega_X,\Omega_X)\).
+ \end{enumerate}
+\end{proposition}
+\begin{proof}
+ Let \(\sigma\) be a winning strategy for \(\plII\) in \(\Omega FO(X)\).
+ For \(s\in([X]^{<\omega})^{<\omega}\), let \(\mc U_s=\{\sigma(s\concat\<F\>:F\in[X]^{<\omega}\}\). 
+ Then define the strategy \(\tau\) for \(\plI\) by \(\tau(s)=\sigma(\<\mc U_{s\rest 0},\dots,\mc U_s\>)\). 
+ Then every attack \(f\) against \(\tau\) yields \(g\in([X]^{<\omega})^\omega\) such that \(f(n)=\sigma(g\rest n+1)\). 
+ Thus \(\{f(n):n<\omega\}=\{\sigma(g\rest n+1):n<\omega\}\) is not an \(\omega\)-cover, so \(\tau\) is a winning strategy, verifying that (a) implies (c).
+
+ The equivalence of (c) and (d) is given by Thm2 of [http://eudml.org/doc/212209].
+
+ Let \(\sigma\) be a winning predetermined strategy for \(\plI\) in \(G_1(\Omega_x,\Omega_x)\). For \(F\in[X]^{<\omega}\) and \(n<\omega\), let \(\tau(F,n)\) be any open set in \(\sigma(n)\) containing \(F\). 
+ It follows that \(\tau\) is a winning Markov strategy for \(\plII\) in \(\Omega FO(X)\), verifying that (c) implies (b).
+
+ (b) implies (a) is trivial, so the proof is complete.
+\end{proof}
+
+\(\Omega R\) is equivalent to all finite powers being \(R\): Thm3 of [http://eudml.org/doc/212209]. 
+It is consistent that these notions do not coincide: see Thm9 of [http://dx.doi.org/10.1016/j.topol.2013.07.022] for a consistent example of a \(T_{3.5}\) \(R\) space whose square is not \(R\), so therefore not \(\Omega R\). 
+Note the distinction with strategies for the opponent, as \(R^+\) is equivalent to \(\Omega R^+\) and \(R^{+mark}\) is equivalent to \(\Omega R^{+mark}\).
+
+Finally we will examine the point-picking games.
+
+\begin{proposition}
+The following properties imply lower properites for all spaces \(X\).
+ \begin{enumerate}[a)]
+  \item \(\plI\win\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\).
+  \item \(\plII\win CL(X,x)\).
+  \item \(\plII\win\gruClusGame{X}{x}\).
+  \item \(\plI\win\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\).
+ \end{enumerate}
+\end{proposition}
+\begin{proof}
+ Begin by letting \(\sigma\) be a winning strategy for \(\plI\) in \(\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\). 
+ For \(s\in T_{X}^{<\omega}\), assume \(\tau(s\rest i+1)\) is defined for \(i<|s|\), defining \(s'\in X^{|s|}\) by \(s'(i)=\tau(s\rest i+1)\), and let \(\tau(s\concat\<U\>)\in\sigma(s')\cap U\). 
+ So \(\tau\) is a strategy for \(\plII\) in \(CL(X,x)\). Then for any attack \(f\) against \(\tau\), an attack \(f'\) against \(\sigma\) is defined by \(f'(i)=\tau(f\rest i+1)\). 
+ It follows that \(\{f'(i):i<\omega\}=\{\tau(f\rest i+1):i<\omega\}\not\in\Omega_{X,x}\), so \(\tau\) is a winning strategy, witnessing (a) implies (b).
+
+ Let \(\sigma\) be a winning strategy for \(\plII\) in \(CL(X,x)\). 
+ Then \(\sigma\) is also a winning strategy for \(\plII\) in \(\gruClusGame{X}{x}\), so (b) implies (c).
+
+ Given a winning strategy \(\sigma\) for \(\plII\) in \(\gruClusGame{X}{x}\), let \(s\in {T_{X,x}}^{<\omega}\) and suppose and \(B_t\in\Omega_{X,x}\) is defined for all \(t<s\). 
+ Then let \(B_s=\{\sigma(s\concat\<U\>):U\in T_{X,x}\}\); it's clear that \(B_s\in\Omega_{X,x}\). 
+ Define \(\tau\) for \(\plI\) in \(\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\) by \(\tau(r)=B_{r'}\) where \(r'\in {T_{X,x}}^{|r|}\) satisfies \(r(i)=\sigma(r'\rest i+1)\) for all \(i<|r|\). 
+ Then an attack \(f\) against \(\tau\) yields an attack \(f'\) against \(\sigma\) such that \(f(i)=\sigma(f'\rest i+1)\) for all \(i<\omega\). 
+ Since \(\sigma\) is a winning strategy, it follows that \(\{f(i):i<\omega\}=\{\sigma(f'\rest i+1):i<\omega\}\not\in\Omega_{X,x}\). 
+ This verifies (c) implies (d).
+\end{proof}
+
+\begin{proposition}
+ The following properties imply lower properites for all spaces \(X\).
+ \begin{enumerate}[a)]
+  \item \(\plI\prewin\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\).
+  \item \(\plII\markwin CL(X,x)\).
+  \item \(\plII\markwin\gruClusGame{X}{x}\).
+  \item \(\plI\prewin\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\).
+ \end{enumerate}
+\end{proposition}
+\begin{proof}
+ Begin by letting \(\sigma\) be a winning predetermined strategy for \(\plI\) in \(\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\). 
+ Define the Markov strategy \(\tau\) for \(\plII\) in \(CL(X,x)\) by \(\tau(U,n)\in\sigma(n)\cap U\). 
+ Since \(\tau(U,n)\in\sigma(n)\) for all \(n<\omega\), it's clear that \(\{\tau(U,n):n<\omega\}\not\in\Omega_{X,x}\), making \(\tau\) a winning strategy, witnessing (a) implies (b).
+
+ Let \(\sigma\) be a winning Markov strategy for \(\plII\) in \(CL(X,x)\). Then \(\sigma\) is also a winning Markov strategy for \(\plII\) in \(\gruClusGame{X}{x}\), so (b) implies (c).
+
+ Given a winning Markov strategy \(\sigma\) for \(\plII\) in \(\gruClusGame{X}{x}\), let \(\tau(n)=\{\sigma(U,n):U\in T_{X,x}\). 
+ Then \(\tau\) is a predetermined strategy for \(\plI\) in \(\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\). 
+ For any attack \(f\) against \(\tau\), \(f(n)=\sigma(g(n),n)\) for some \(g(n)\in T_{X,x}\). 
+ But then \(g\) is an attack against \(\sigma\), and thus \(\{f(n):n<\omega\}=\{\sigma(g(n),n):n<\omega\}\not\in\Omega_{X,x}\), so we have (c) implies (d).
+\end{proof}
+
+Note that for \(C_p(X)\) with \(X\) \(T_{3.5}\), (a)-(d) in both of the above propositions are actually equivalent.
+
+\begin{theorem}
+ The following are equivalent for all \(T_{3.5}\) spaces.
+ \begin{enumerate}[a)]
+  \item \(\plII\win \Omega FO(X)\).
+  \item \(\plII\markwin \Omega FO(X)\).
+  \item \(\plI\win G_1(\Omega_X,\Omega_X)\).
+  \item \(X\) is not \(\Omega R\), that is, \(\plI\prewin G_1(\Omega_X,\Omega_X)\).
+  \item \(\plI\win\schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\).
+  \item \(C_p(X)\) is not \(sCFT\), that is, \(\plI\prewin \schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\).
+  \item \(\plI\win\schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\).
+  \item \(C_p(X)\) is not \(sCDFT\), that is, \(\plI\prewin \schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\).
+  \item \(\plII\win\gruClusGame{C_p(X)}{\mathbf 0}\).
+  \item \(\plII\markwin\gruClusGame{C_p(X)}{\mathbf 0}\).
+  \item \(\plII\win CL(C_p(X),\mathbf 0)\).
+  \item \(\plII\markwin CL(C_p(X),\mathbf 0)\).
+  \item \(\plII\win CD(C_p(X))\).
+  \item \(\plII\markwin CD(C_p(X))\).
+ \end{enumerate}
+\end{theorem}
+\begin{proof}
+ (a)-(d) were shown in Proposition 18.
+ The equivalence of (d), (f), and (h) was shown by Sakai.
+ The equivalence of (f) and (e) is given in 4.37 of [Comb. of Open Covers in Gen Prog Top III].
+
+ Of course (h) implies (g). And since \(\mc D_{C_p(X)}\subseteq\Omega_{C_p(X),\mathbf 0}\), any winning strategy for \(\plI\) in \(\schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\) is a winning strategy for \(\plI\) in \(\schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\), so (g) implies (e). 
+ We have so far shown that (a) - (h) are equivalent.
+
+ Proposition 19 established that (e), (g), (i), and (k) are equivalent.
+ Proposition 20 established that (f), (h), (j), and (l) are equivalent.
+ Thus (a) - (l) are equivalent.
+
+ Assuming (b), we adapt Proposition 3.9 of [Tkachuk Two Point-Picking Games] as follows.
+ Let \(\sigma\) be a winning Markov strategy for \(\plII\) in \(\Omega FO(X)\). 
+ Then for \(U=[\mathbf x(U),supp(U),\epsilon(U)]\in T_{C_p(X)}\), let \(\tau(U,n)\in C_p(X)\) satisfy  \(\tau(U,n)(x)=\mathbf x(U)(x)\) for \(x\in F\) and \(\tau(U,n)(x)=n\) for \(x\in X\setminus\sigma(U,n)\). 
+ Then \(\tau\) is a Markov strategy for \(\plII\), and when it is attacked by \(f\), we note that \(\{\sigma(supp(f(n)),n):n<\omega\}\) is not an \(\omega\)-cover. 
+ So choose \(G\in[X]^{<\omega}\) such that \(G\not\subseteq\sigma(supp(f(n)),n)\) for all \(n<\omega\). 
+ Then for \(\mathbf y\in C_p(X)\), choose \(m\) such that \(\mathbf y(x)<m\) for all \(x\in G\). 
+ Note then that for \(n\geq m\), there exists \(x\in G\setminus\sigma(f(n),n)\) such that \(\tau(f(n),n)(x)=n\geq m\). 
+ Then \(\{\mathbf z\in C_p(X):\mathbf z(x)<m\text{ for all }x\in G\}\) is an open neighborhood of \(\mathbf y\) that misses \(\tau(f(n),n)\) for all \(n\geq m\), so it follows that \(\{\tau(f(n),n):n<\omega\}\) is closed and discrete in \(C_p(X)\). 
+ Therefore \(\tau\) is a winning Markov strategy, verifying (b) implies (n).
+
+ It's clear that (n) implies (m), so finally note that a winning strategy for \(\plII\) in \(CD(C_p(X))\) is also a winning strategy for \(\plII\) in \(CL(C_p(X),\mathbf 0)\), so (m) implies (k).
+\end{proof}
+
+The equivalence of (a) and (m) answers Quesiton 4.6 of Tkachuk in [Two Point-picking games].
+
+\section{The Discrete Selection Game on Function Spaces of Cardinals}
 
 \begin{game}
   Let \(G\) be the following game. During round \(n\), player \(\plI\)
@@ -292,485 +605,9 @@ For \(f\in\omega^\alpha\), let
   Thus \(\mathbf{0}\in\operatorname{cl}\{\nu(n):n<\omega\}\).
 \end{proof}
 
-\section{Combining game results}
+\section{Open Problems}
 
-\begin{theorem}
-The following are equivalent for \(T_{3.5}\) spaces \(X\).
-\begin{enumerate}[a)]
-\item \(X\) is \(R^+\), that is, \(\plII\win \schStrongSelGame{\mc O_X}{\mc O_X}\).
-\item \(\plI\win PO(X)\). 
-\item \(\plI\win FO(X)\).
-\item \(\plI\win\Omega FO(x)\).
-\item \(\plI\win \gruConGame{C_p(X)}{\mathbf 0}\).
-\item \(\plI\win \gruClusGame{C_p(X)}{\mathbf 0}\).
-\item \(\plI\win CL(C_p(X),\mathbf 0)\).
-\item \(\plI\win CD(C_p(X))\).
-\item \(X\) is \(\Omega R^+\), that is, 
-  \(\plII\win \schStrongSelGame{\Omega_X}{\Omega_X}\).
-\item \(C_p(X)\) is \(sCFT^+\), that is, 
-  \(\plII\win \schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\).
-\item \(C_p(X)\) is \(sCDFT^+\), that is,
-  \(\plII\win \schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\).
-\end{enumerate}
-\end{theorem}
-
-\begin{proof}
-  (a) \(\Leftrightarrow\) (b) is a well-known result of Galvin.
-
-  (b) \(\Leftrightarrow\) (c) is 4.3 of [Telgarksy 1975].
-  
-  (d) \(\Leftrightarrow\) (c) is clear, but we need to show that (a) \(\Leftrightarrow\) (d).
-  So assume \(X\) is \(R^+\), which is equivalent to \(\Omega R^+\). 
-  Let \(\sigma\) be a winning strategy for \(\plII\) in 
-  \(\schStrongSelGame{\Omega_X}{\Omega_X}\). Let \(T(X)\) be the non-empty
-  open sets of \(X\), and let \(s\in T(X)^{<\omega}\).
-  Assume \(\tau(t)\in[X]^{<\omega}\) is defined for all \(t<s\),
-  and \(\mc U_t\in\Omega_X\) is defined for all 
-  \(\emptyset<t\leq s\). 
-
-  Suppose that for all \(F\in[X]^{<\omega}\), there existed \(U_F\in T(X)\)
-  containing \(F\) such that for all \(\mc U\in\Omega_X\),
-  \(U_F\not=\sigma(\<\mc U_{s\rest 1},\dots,U_s,\mc U\>)\).
-  Let \(\mc U=\{U_F:F\in[X]^{<\omega}\}\in\Omega_X\).
-  Then \(\sigma(\<\mc U_{s\rest 1},\dots,U_s,\mc U\>)\)
-  must equal some \(U_F\), demonstrating a contradiction.
-
-  So there exists \(\tau(s)\in[X]^{<\omega}\) such that for all \(U\in T(X)\)
-  containing \(\tau(s)\),
-  there exists \(\mc U_{s\concat\<U\>}\in\Omega_X\) such that
-  \(U=\sigma(\<\mc U_{s\rest 1},\dots,\mc U_s,\mc U_{s\concat\<U\>}\>)\).
-  (To complete the induction, \(\mc U_{s\concat\<U\>}\) may be chosen
-  arbitrarily for all other \(U\in T(X)\).)
-
-  So \(\tau\) is a strategy for \(\plI\) in \(\Omega FO(X)\).
-  Let \(\nu\) legally attack \(\tau\), so
-  \(\tau(\nu\rest n)\subseteq \nu(n)\) for all \(n<\omega\).
-  It follows that 
-  \(\nu(n)=\sigma(\<\mc U_{\nu\rest 1},\dots,\mc U_{\nu\rest n},\mc U_{\nu\rest n+1}\>)\).
-  Since \(\<\mc U_{\nu\rest 1},\mc U_{n\rest 2},\dots\>\) is a legal attack
-  against \(\sigma\), it follows that
-  \(\{\sigma(\<\mc U_{\nu\rest 1},\dots,\mc U_{\nu\rest n+1}\>):n<\omega\}=\{\nu(n):n<\omega\}\)
-  is an \(\omega\)-cover. Therefore \(\tau\) is a winning strategy, 
-  verifying \(\plI\win\Omega FO(X)\).
-
-  The equivalence of (b), (e), (g), and (h) are given as 3.8 of [Tkachuk 2017].
-
-  The equivalence of (e) is (f) are given in [https://doi.org/10.1016/0016-660X(76)90024-6].
-  
-  The equivalence of (i), (j), and (k) are due to Clontz's Menger preprint.
-
-  (k) \(\Leftrightarrow\) (g) follows from 3.18a of [Tkachuk 2017].
-\end{proof}
-
-Tkachuk showed the following in [CLOSEDDISCRETESELECTIONS].
-
-\begin{theorem}
-The following are equivalent for \(T_{3.5}\) spaces \(X\).
-\begin{enumerate}[a)]
-\item \(X\) is uncountable.
-\item \(C_p(X)\) has discrete selectivity, that is,
-      \(\plI\notprewin CD(C_p(X))\).
-\end{enumerate}
-\end{theorem}
-
-Clontz came across these in grad school (didn't make it into the dissertation):
-
-\renewcommand{\rothGame}[1]{\ensuremath{G_1(\mc O_{#1},\mc O_{#1})}}
-\begin{theorem}
-\(\plI\prewin PO(X)\) if and only if \(\plII\markwin\rothGame{X}\).
-\end{theorem} 
-\begin{proof}
-Let \(\sigma\) be a winning Markov strategy for \(\plII\) in \(\rothGame{X}\).
-Let \(n<\omega\). Suppose that for each \(x\in X\), there was an open neighborhood 
-\(U_x\) of \(x\) where for every open cover \(\mc U\), \(\sigma(\mc U,n)\not=U_x\). 
-Then \(\sigma(\{U_x : x\in X\},n)\not\in\{U_x:x\in X\}\), a contradiction.
-
-So for each \(n<\omega\), there exists \(\tau(n)\in X\) such that for any
-open neighborhood \(U\) of \(\tau(n)\), there exists an open cover \(\mc U_n\)
-such that \(\sigma(\mc U_n,n)=U\). Then \(\tau\) is a predetermined strategy for
-\(\plI\) in \(PO(X)\).
-
-It is also winning: for every attack \(f\) against \(\tau\), note that
-\(f(n)\) is an open neighborhood of \(\tau(n)\), so choose \(\mc U_n\)
-such that \(\sigma(\mc U_n,n)=f(n)\). Then since \(\<\mc U_0,\mc U_1,\dots\>\)
-is a legal attack against \(\sigma\), it follows that \(\{f(n):n<\omega\}\)
-is an open cover of \(X\). Therefore \(\tau\) is a winning predetermined
-strategy.
-
-Now let \(\sigma\) be a winning predetermined strategy for \(\plI\) in \(PO(X)\).
-For an open cover \(\mc U\) of \(X\) and \(n<\omega\), let \(\tau(\mc U,n)\)
-be any open set in \(\mc U\) containing \(\sigma(n)\). It follows
-that \(\tau\) is a winning Markov strategy for \(\plII\) in \(\rothGame{X}\).
-\end{proof}
-
-\begin{theorem}
-\(\plII\markwin PO(X)\) if and only if \(\plI\prewin\rothGame{X}\).
-\end{theorem}
-\begin{proof}
-Let \(\sigma\) be a winning predetermined strategy for \(\plI\) in \(\rothGame{X}\).
-For \(x\in X\) and \(n<\omega\), let \(\tau(x,n)\) be any open set in \(\sigma(n)\)
-containing \(x\). It follows that \(\tau\) is a winning Markov strategy for
-\(\plII\) in \(PO(X)\).
-
-Now let \(\sigma\) be a winning Markov strategy for \(\plII\) in \(PO(X)\).
-We may defined the open cover \(\tau(n)=\{\sigma(x,n):x\in X\}\) of \(X\).
-It follows that \(\tau\) is a winning predetermined strategy for \(\plI\)
-in \(\rothGame{X}\).
-\end{proof}
-
-
-Combining with several other results in the literature,
-we may observe the following.
-
-\begin{theorem}
-The following are equivalent for \(T_{3.5}\) spaces \(X\).
-\begin{enumerate}[a)]
-\item \(X\) is countable.
-\item \(X\) is \(R^{+mark}\).
-\item \(\plI\prewin PO(X)\). 
-\item \(\plI\prewin FO(X)\).
-\item \(\plI\prewin\Omega FO(x)\).
-\item \(C_p(X)\) is first-countable.
-\item \(\plI\prewin \gruConGame{C_p(X)}{\mathbf 0}\).
-\item \(\plI\prewin \gruClusGame{C_p(X)}{\mathbf 0}\).
-\item \(\plI\prewin CL(C_p(X),\mathbf 0)\).
-\item \(\plI\prewin CD(C_p(X))\).
-\item \(X\) is \(\Omega R^{+mark}\).
-\item \(C_p(X)\) is \(sCFT^{+mark}\).
-\item \(C_p(X)\) is \(sCDFT^{+mark}\).
-\end{enumerate}
-\end{theorem}
-
-\begin{proof}
-(a) implies (c) is straight-forward. So let
-\(\sigma\) be a predetermined strategy for \(\plI\) in \(PO(X)\).
-If \(x\not\in\{\sigma(n):n<\omega\}\), let \(f(n)=X\setminus\{x\}\)
-for all \(n<\omega\). It follows that \(f\) is a legal
-counter-attack for \(\plII\) defeating \(\sigma\). Thus not (a) implies
-not (c).
-
-The equivalence of (b) and (c) was shown above.
-
-Clearly (c) implies (d), so we will see that (d) implies (a).
-Let \(\sigma(n)\) be a pre-determined strategy for I for \(FO(X)\).
-Towards a contradiction, suppose that there is some \(x \in X \smallsetminus \bigcup_n \sigma(n)\).
-II could then play \(FO(X)\) as follows.
-At round \(n\) II can play an open set \(U_n\) which contains \(\sigma(n)\) but excludes \(x\).
-Then \(x \notin \bigcup_n U_n\), and so I has lost.
-This is a contradiction.
-So \(X = \bigcup_n \sigma(n)\), which means it is countable.
-
-It also clear that (e) implies (d), we will show that (a) implies (e).
-If \(X\) is countable, then so is \([X]^{<\omega}\), enumerate it as \(\{s_n : n \in \omega\}\).
-I's pre-determined strategy for \(\Omega FO(X)\) is to play \(s_n\) are round \(n\).
-Clearly whatever II plays will be an \(\omega\)-cover.
-Thus (a) - (e) are equivalent.
-
-It is well-known and easy to see that (a) is equivalent to (f).
-
-To see that (f) implies (g), note that we can find a sequence of open sets \(U_n\) so that \(\mathbf 0 \in U_{n+1} \subseteq \overline{U_{n+1}} \subseteq U_n\) for all \(n\).
-I simply plays \(U_n\) are turn \(n\), and whatever \(x_n\) are played by II must converge to \(x\).
-
-Clearly (g) implies (i) which in turn implies (j), which is
-equivalent to (a) by [CLOSEDDISCRETESELECTIONS] 
-%Let \(\sigma(n)\) be a pre-determined strategy for I for \(CD(C_p(X))\).
-%Towards a contradiction suppose \(X\) is uncountable.
-%Without loss of generality we can assume that \(\sigma(n)\) is a basic open set, \([f_n,F_n,\varepsilon_n]\).
-%If I is not already playing basic open sets, we can choose basic open subsets of I's play, and the resulting game will still produce a a sequence \(\{x_n : n \in \omega\}\) which is not closed discrete.
-%Let \(F = \bigcup_n F_n\).
-%As \(X\) is uncountable, we can choose a point \(x \in X \smallsetminus F\).
-%Then II can play against \(\sigma\) by playing a function \(g_n\) at round \(n\) with the properties that \(g_n \in [f_n,F_n,\varepsilon_n]\) and \(g_n(x) = n\).
-%The collection \(\{g_n : n \in \omega\}\) is then closed discrete, and so I has lost.
-%This is a contradiction, so \(X\) must be countable.
-%Thus (a) - (i) are equivalent.
-
-Clontz showed (g) and (h) are equivalent in his dissertation; it's
-not hard to prove this.
-
-Clontz showed that (k), (l), and (m) are equivalent in his
-Menger/CFT preprint.
-
-Note that (k) implies (b) implies (a).
-So the last thing we need to show is that (e) implies (k).
-Let \(\sigma(n)\) be a pre-determined strategy for I for \(\Omega FO(X)\).
-We define a Markov strategy, \(\tau(\mathcal{U},n)\) for II for \(\Omega R\) as follows.
-At round \(n\) suppose I has played \(\mathcal{U}\).
-As \(\mathcal{U}\) must be an \(\omega\)-cover, there is a \(U \in \mathcal{U}\) so that \(\sigma(n) \subseteq U\).
-II plays such a \(U_n\).
-Now suppose this game has been played according to \(\tau\), and that I has played \(\mathcal{U}_n\) for \(n < \omega\).
-Then the sequence of open sets \(\tau(\mathcal{U}_n,n)\) forms a legal play against \(\sigma\) for \(\Omega FO(X)\).
-Thus \(\{\tau(\mathcal{U}_n,n) : n \in \omega\}\) is an \(\omega\)-cover of \(X\) and so \(\tau\) is a winning Markov strategy.
-\end{proof}
-
-In that paper, Tkachuk characterizes \(\plII\win\Omega FO(X)\)
-as the second player having an ``almost winning strategy''
-(\(\plII\) can prevent \(\plI\) from constructing an \(\omega\)-cover
-but perhaps not an arbitrary open cover)
-in \(PO(X)\), which he conflates with \(FO(X)\) as they are
-equivalent for ``completely'' winning perfect information strategies. 
-
-But they cannot be interchanged in general.
-Note that \(\plII\tactwin\Omega PO(2)\), where \(2\) is the two-point discrete space:
-let \(\sigma(\<x\>)=\{x\}\). Since every \(\omega\)-cover of \(2\) includes \(2\),
-and \(\sigma\) never produces \(2\), this is a winning tactic. But since \(2\)
-is countable, \(2\) is \(\Omega R^{+mark}\).
-So \(\Omega PO(X)\) is a very different game than those described previously.
-
-
-Now we turn our attention to the opponent.
-
-\begin{theorem}
-The following are equivalent for all spaces \(X\).
-\begin{enumerate}[a)]
-\item \(\plII\win FO(X)\)
-\item \(\plII\win PO(X)\)
-\item \(\plI\win \rothGame{X}\)
-\item \(X\) is not \(R\), that is, \(\plI\prewin \rothGame{X}\)
-\item \(\plII\markwin PO(X)\)
-\item \(\plII\markwin FO(X)\)
-\end{enumerate}
-\end{theorem}
-\begin{proof}
-(a) \(\Leftrightarrow\) (b) is 4.4 of [Telgarksy 1975].
-
-The duality of \(PO(X)\) and \(\rothGame{X}\) for both players
-when considering perfect information is a well-known result of Galvin.
-So (b) is equivalent to (c).
-
-The equivalence of (c) and (d) is just a restatement of Pawlikowski's
-result that the Rothberger selection principle is equivalent
-to \(\plI\notwin \rothGame{X}\), since the Rothberger selection principle
-is equivalent to \(\plI\notprewin\rothGame{X}\).
-
-(d) and (e) were shown to be equivalent above.
-
-Finally, (f) implies (e) is obvious. 
-Let \(b:\omega^2\to\omega\) be a bijection.
-Given a winning Markov strategy \(\sigma\) for \(\plII\) in \(PO(X)\),
-define \(\tau(F_n,n)=\bigcup\{\sigma(x(i,n),b(i,n)):i<\omega\}\)
-where \(F_n=\{x(i,n):i<\omega\}\) (this indexing will cause at least one 
-point to be repeated infinitely often, but this won't be a problem). 
-So given an attack \(\<F_0,F_1,\dots\>\) \
-against \(\tau\), consider the attack \(g\) against \(\sigma\), 
-where \(g(n)=x_{b^{\leftarrow}(n)}\). It follows that
-\[
-  X
-    \not=
-  \bigcup\{\sigma(g(n),n):n<\omega\}
-    =
-  \bigcup\{\sigma(x(i,n),b(i,n)):i,n<\omega\}
-    =
-  \bigcup\{\tau(F_n,n):n<\omega\}
-\]
-and therefore \(\tau\) is a winning Markov strategy for \(\plII\).
-Thus (e) implies (f).
-\end{proof}
-
-\begin{theorem}
-The following are equivalent for all spaces \(X\).
-\begin{enumerate}[a)]
-\item \(\plII\win \Omega FO(X)\)
-\item \(\plI\win G_1(\Omega_X,\Omega_X)\)
-\item \(X\) is not \(\Omega R\), that is, \(\plI\prewin G_1(\Omega_X,\Omega_X)\)
-\item \(\plII\markwin \Omega FO(X)\)
-\end{enumerate}
-\end{theorem}
-\begin{proof}
-Let \(\sigma\) be a winning strategy for \(\plII\) in \(\Omega FO(X)\).
-For \(s\in([X]^{<\omega})^{<\omega}\), let 
-\(\mc U_s=\{\sigma(s\concat\<F\>:F\in[X]^{<\omega}\}\).
-Then define the strategy \(\tau\) for \(\plI\) by 
-\(\tau(s)=\sigma(\<\mc U_{s\rest 0},\dots,\mc U_s\>)\).
-Then every attack \(f\) against \(\tau\) yields \(g\in([X]^{<\omega})^\omega\)
-such that \(f(n)=\sigma(g\rest n+1)\). Thus 
-\(\{f(n):n<\omega\}=\{\sigma(g\rest n+1):n<\omega\}\)
-is not an \(\omega\)-cover, so \(\tau\) is a winning strategy,
-verifying that (a) implies (b).
-
-The equivalence of (b) and (c) is given by Thm2 of
-[http://eudml.org/doc/212209].
-
-Let \(\sigma\) be a winning predetermined strategy for \(\plI\)
-in \(G_1(\Omega_x,\Omega_x)\). For \(F\in[X]^{<\omega}\) and
-\(n<\omega\), let \(\tau(F,n)\) be any open set in \(\sigma(n)\)
-containing \(F\). It follows that \(\tau\) is a winning Markov
-strategy for \(\plII\) in \(\Omega FO(X)\), verifying that
-(c) implies (d).
-
-(d) implies (a) is trivial, so the proof is complete.
-\end{proof}
-
-\(\Omega R\) is equivalent to all finite powers being \(R\):
-Thm3 of [http://eudml.org/doc/212209].
-These notions cannot coincide: see Thm9 of 
-[http://dx.doi.org/10.1016/j.topol.2013.07.022] 
-for a consisent example of a \(R\) space whose square
-is not \(R\), so therefore not \(\Omega R\). 
-Note the distinction with strategies for the opponent, as \(R^+\) is
-equivalent to \(\Omega R^+\) and \(R^{+mark}\) is
-equivalent to \(\Omega R^{+mark}\).
-
-\begin{corollary}
-The following are equivalent for all \(T_{3.5}\) spaces.
-\begin{enumerate}[a)]
-\item \(\plII\win \Omega FO(X)\)
-\item \(\plII\markwin \Omega FO(X)\)
-\item \(\plI\win G_1(\Omega_X,\Omega_X)\)
-\item \(X\) is not \(\Omega R\), that is, \(\plI\prewin G_1(\Omega_X,\Omega_X)\)
-\item \(C_p(X)\) is not \(sCFT\), that is, 
-  \(\plI\prewin \schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\).
-\item \(\plI\win \schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\).
-\item \(C_p(X)\) is not \(sCDFT\), that is,
-  \(\plI\prewin \schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\).
-\item \(\plI\win \schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\).
-\end{enumerate}
-\end{corollary}
-\begin{proof}
-(a)-(d) were just shown.
-The equivalence of (d),(e),(g) was shown by Sakai.
-The equivalence of (e) and (f) is given in 4.37 of [Comb. of Open Covers in Gen Prog Top III].
-
-Of course (g) implies (h). And since \(\mc D_{C_p(X)}\subseteq\Omega_{C_p(X),\mathbf 0}\),
-any winning strategy for \(\plI\) in \(\schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\)
-is a winning strategy for \(\plI\) in 
-\(\schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\),
-so (h) implies (f).
-\end{proof}
-
-\begin{theorem}
-The following properties imply lower properites for all spaces \(X\).
-\begin{enumerate}[a)]
-\item \(\plI\win\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\)
-\item \(\plII\win CL(X,x)\)
-\item \(\plII\win\gruClusGame{X}{x}\)
-\item \(\plI\win\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\)
-\end{enumerate}
-\end{theorem}
-\begin{proof}
-Begin by letting \(\sigma\) be a winning strategy for
-\(\plI\) in \(\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\).
-For \(s\in T_{X}^{<\omega}\), assume \(\tau(s\rest i+1)\) 
-is defined for \(i<|s|\), defining \(s'\in X^{|s|}\)
-by \(s'(i)=\tau(s\rest i+1)\), and let
-\(\tau(s\concat\<U\>)\in\sigma(s')\cap U\).
-So \(\tau\) is a strategy for \(\plII\) in \(CL(X,x)\).
-Then for any attack \(f\) against \(\tau\),
-an attack \(f'\) against \(\sigma\) is defined by
-\(f'(i)=\tau(f\rest i+1)\). It follows that
-\(\{f'(i):i<\omega\}=\{\tau(f\rest i+1):i<\omega\}\not\in\Omega_{X,x}\),
-so \(\tau\) is a winning strategy, witnessing (a) implies (b).
-
-Let \(\sigma\) be a winning strategy for \(\plII\) in
-\(CL(X,x)\). Then \(\sigma\) is also a winning strategy
-for \(\plII\) in \(\gruClusGame{X}{x}\), so (b) implies (c).
-
-Given a winning strategy \(\sigma\) for \(\plII\) in
-\(\gruClusGame{X}{x}\), let \(s\in {T_{X,x}}^{<\omega}\) and suppose
-and \(B_t\in\Omega_{X,x}\) is defined for all \(t<s\).
-Then let \(B_s=\{\sigma(s\concat\<U\>):U\in T_{X,x}\}\);
-it's clear that \(B_s\in\Omega_{X,x}\).
-Define \(\tau\) for \(\plI\) in \(\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\)
-by \(\tau(r)=B_{r'}\) where \(r'\in {T_{X,x}}^{|r|}\) satisfies
-\(r(i)=\sigma(r'\rest i+1)\) for all \(i<|r|\). Then an attack \(f\)
-against \(\tau\) yields an attack \(f'\) against \(\sigma\)
-such that \(f(i)=\sigma(f'\rest i+1)\) for all \(i<\omega\).
-Since \(\sigma\) is a winning strategy, it follows that
-\(\{f(i):i<\omega\}=\{\sigma(f'\rest i+1):i<\omega\}\not\in\Omega_{X,x}\).
-This verifies (c) implies (d).
-\end{proof}
-
-\begin{theorem}
-The following properties imply lower properites for all spaces \(X\).
-\begin{enumerate}[a)]
-\item \(\plI\prewin\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\)
-\item \(\plII\markwin CL(X,x)\)
-\item \(\plII\markwin\gruClusGame{X}{x}\)
-\item \(\plI\prewin\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\)
-\end{enumerate}
-\end{theorem}
-\begin{proof}
-Begin by letting \(\sigma\) be a winning predetermined strategy for
-\(\plI\) in \(\schStrongSelGame{\mc D_X}{\Omega_{X,x}}\).
-Define the Markov strategy \(\tau\) for \(\plII\) in \(CL(X,x)\)
-by \(\tau(U,n)\in\sigma(n)\cap U\).
-Since \(\tau(U,n)\in\sigma(n)\) for all \(n<\omega\),
-it's clear that \(\{\tau(U,n):n<\omega\}\not\in\Omega_{X,x}\),
-making \(\tau\) a winning strategy, witnessing (a) implies (b).
-
-Let \(\sigma\) be a winning Markov strategy for \(\plII\) in
-\(CL(X,x)\). Then \(\sigma\) is also a winning Markov strategy
-for \(\plII\) in \(\gruClusGame{X}{x}\), so (b) implies (c).
-
-Given a winning Markov strategy \(\sigma\) for \(\plII\) in
-\(\gruClusGame{X}{x}\), let 
-\(\tau(n)=\{\sigma(U,n):U\in T_{X,x}\).
-Then \(\tau\) is a predetermined strategy for \(\plI\) in
-\(\schStrongSelGame{\Omega_{X,x}}{\Omega_{X,x}}\).
-For any attack \(f\) against \(\tau\),
-\(f(n)=\sigma(g(n),n)\) for some \(g(n)\in T_{X,x}\).
-But then \(g\) is an attack against \(\sigma\), and
-thus \(\{f(n):n<\omega\}=\{\sigma(g(n),n):n<\omega\}\not\in\Omega_{X,x}\),
-so we have (c) implies (d).
-\end{proof}
-
-Note that for \(C_p(X)\), (a)-(d) in both of the above theorems
-are actually equivalent.
-
-\begin{corollary}
-The following are equivalent for all \(T_{3.5}\) spaces.
-\begin{enumerate}[a)]
-\item \(\plII\win \Omega FO(X)\)
-\item \(\plII\markwin \Omega FO(X)\)
-\item \(\plI\win G_1(\Omega_X,\Omega_X)\)
-\item \(X\) is not \(\Omega R\), that is, \(\plI\prewin G_1(\Omega_X,\Omega_X)\)
-\item \(C_p(X)\) is not \(sCFT\), that is, 
-  \(\plI\prewin \schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\).
-\item \(\plI\win\schStrongSelGame{\Omega_{C_p(X),\mathbf 0}}{\Omega_{C_p(X),\mathbf 0}}\)
-\item \(C_p(X)\) is not \(sCDFT\), that is,
-  \(\plI\prewin \schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\).
-\item \(\plI\win\schStrongSelGame{\mc D_{C_p(X)}}{\Omega_{C_p(X),\mathbf 0}}\)
-\item \(\plII\markwin\gruClusGame{C_p(X)}{\mathbf 0}\)
-\item \(\plII\win\gruClusGame{C_p(X)}{\mathbf 0}\)
-\item \(\plII\markwin CL(C_p(X),\mathbf 0)\)
-\item \(\plII\win CL(C_p(X),\mathbf 0)\)
-\item \(\plII\markwin CD(C_p(X))\)
-\item \(\plII\win CD(C_p(X))\)
-\end{enumerate}
-\end{corollary}
-\begin{proof}
-We've established (a)-(l) are equivalent.
-Assuming (b), we adapt Proposition 3.9 of
-[Tkachuk Two Point-Picking Games] as follows.
-Let \(\sigma\) be a winning Markov strategy for
-\(\plII\) in \(\Omega FO(X)\). Then for 
-\(U=[\mathbf x(U),supp(U),\epsilon(U)]\in T_{C_p(X)}\),
-let \(\tau(U,n)\in C_p(X)\) satisfy \(\tau(U,n)(x)=\mathbf x(U)(x)\)
-for \(x\in F\) and \(\tau(U,n)(x)=n\) for 
-\(x\in X\setminus\sigma(U,n)\). Then \(\tau\) is a Markov
-strategy for \(\plII\), and when it is attacked by 
-\(f\), we note that \(\{\sigma(supp(f(n)),n):n<\omega\}\)
-is not an \(\omega\)-cover. So choose \(G\in[X]^{<\omega}\)
-such that \(G\not\subseteq\sigma(supp(f(n)),n)\) for all \(n<\omega\).
-Then for \(\mathbf y\in C_p(X)\), choose \(m\) such that
-\(\mathbf y(x)<m\) for all \(x\in G\). Note then that 
-for \(n\geq m\), there
-exists \(x\in G\setminus\sigma(f(n),n)\) such that 
-\(\tau(f(n),n)(x)=n\geq m\). Then
-\(\{\mathbf z\in C_p(X):\mathbf z(x)<m\text{ for all }x\in G\}\)
-is an open neighborhood of \(\mathbf y\) that misses
-\(\tau(f(n),n)\) for all \(n\geq m\), so
-it follows that \(\{\tau(f(n),n):n<\omega\}\) is closed and
-discrete in \(C_p(X)\). Therefore \(\tau\) is a winning Markov
-strategy, verifying (b) implies (m).
-
-It's clear that (m) implies (n), so finally note that
-a winning strategy for \(\plII\) in \(CD(C_p(X))\) is also
-a winning strategy for \(\plII\) in \(CL(C_p(X),\mathbf 0)\),
-so (n) implies (l).
-\end{proof}
-
-The equivalence of (a) and (n) 
-answers Quesiton 4.6 of Tkachuk in [Two Point-picking games].
+\section*{Acknowledgements}
 
   \bibliographystyle{plain}
   \bibliography{../bibliography}


### PR DESCRIPTION
I probably did too many changes at once for this workflow. Sorry about that.
1. Added the physical address and email addresses
2. Added an abstract
3. Added an introduction
4. Re-organized the definitions for clarity and compactness
5. Officially organized the sections
6. Combined some results together to make the presentation more concise. Theorems 23 and 24 were repackaged in to the results they were used for and corollary 29 was repackaged in to the main result of the paper.
7. Changed the flow of the portion on strategies for player II from thm thm cor to prop prop thm.
8. Added section for questions and acknowledgments
9. Probably unnecessarily fiddled with the white space in the document.